### PR TITLE
Add support to icp0.io and plug wallet

### DIFF
--- a/src/services/capture/select.test.ts
+++ b/src/services/capture/select.test.ts
@@ -13,6 +13,8 @@ describe('isBoundaryNodeURL', () => {
             'https://boundary.ic0.app/api/v2/canister/upsxs-oyaaa-aaaah-qcaua-cai/read_state',
             'https://www.ic0.app/api/v2/canister/upsxs-oyaaa-aaaah-qcaua-cai/read_state',
             'http://localhost:8000/api/v2/canister/upsxs-oyaaa-aaaah-qcaua-cai/read_state',
+            'https://icp0.io/api/v2/canister/upsxs-oyaaa-aaaah-qcaua-cai/read_state',
+            'https://mainnet.plugwallet.ooo/api/v2/canister/tzvxm-jqaaa-aaaaj-qabga-cai/query',
         ].forEach((url) => {
             const result = isBoundaryNodeURL(url);
             if (!result) console.error(url);

--- a/src/services/capture/select.ts
+++ b/src/services/capture/select.ts
@@ -1,5 +1,5 @@
 const boundaryNodeRegex =
-    /https?:\/\/(?:.+)?((?:ic0\.app|dfinity.network|icp-api.io)|localhost:[0-9]+)\/api\/v2\/canister\/(.+)\/(query|call|read_state)/;
+    /https?:\/\/(?:.+)?((?:ic0\.app|dfinity.network|icp-api.io|icp0.io|mainnet.plugwallet.ooo)|localhost:[0-9]+)\/api\/v2\/canister\/(.+)\/(query|call|read_state)/;
 
 /**
  * Determines whether a URL represents a request to an internet computer boundary node.


### PR DESCRIPTION
This adds support to inspect calls from icp0.io used on `https://app.icpswap.com` and plug wallet.